### PR TITLE
feat: docker upstreams in config.toml, existingSecret support

### DIFF
--- a/charts/nora/templates/configmap.yaml
+++ b/charts/nora/templates/configmap.yaml
@@ -14,6 +14,19 @@ data:
     mode = {{ .Values.config.storage.mode | quote }}
     path = {{ .Values.config.storage.path | quote }}
 
+    {{- if or .Values.config.docker.upstreams .Values.config.docker.proxy_timeout }}
+    [docker]
+    proxy_timeout = {{ .Values.config.docker.proxy_timeout | default 60 }}
+    {{- range .Values.config.docker.upstreams }}
+
+    [[docker.upstreams]]
+    url = {{ .url | quote }}
+    {{- if .auth }}
+    auth = {{ .auth | quote }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+
     [gc]
     enabled = {{ .Values.config.gc.enabled }}
     interval = {{ .Values.config.gc.interval }}

--- a/charts/nora/templates/deployment.yaml
+++ b/charts/nora/templates/deployment.yaml
@@ -79,6 +79,11 @@ spec:
             - name: config
               mountPath: /config
               readOnly: true
+            {{- if .Values.existingSecret }}
+            - name: secrets-config
+              mountPath: /config/secrets
+              readOnly: true
+            {{- end }}
             {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: /data
@@ -89,6 +94,11 @@ spec:
         - name: config
           configMap:
             name: {{ include "nora.fullname" . }}-config
+        {{- if .Values.existingSecret }}
+        - name: secrets-config
+          secret:
+            secretName: {{ .Values.existingSecret }}
+        {{- end }}
         {{- if .Values.persistence.enabled }}
         - name: data
           persistentVolumeClaim:

--- a/charts/nora/values.yaml
+++ b/charts/nora/values.yaml
@@ -59,6 +59,14 @@ config:
   storage:
     mode: local
     path: /data/storage
+  docker:
+    proxy_timeout: 60
+    # -- Docker upstream registries for proxy/cache.
+    # Auth credentials should come from existingSecret, not inline here.
+    upstreams: []
+    #  - url: https://registry-1.docker.io
+    #  - url: https://private.registry.io
+    #    auth: "user:token"
   gc:
     enabled: true
     interval: 86400
@@ -66,6 +74,15 @@ config:
     enabled: false
     interval: 86400
     rules: []
+
+# -- Name of an existing Secret to mount as /config/secrets.toml.
+# Use this to keep registry credentials out of values.yaml.
+# The Secret should contain a key "secrets.toml" with TOML content, e.g.:
+#   [[docker.upstreams]]
+#   url = "https://private.registry.io"
+#   auth = "user:token"
+# These upstreams are merged with config.docker.upstreams (Secret wins for same URL).
+existingSecret: ""
 
 # -- Extra environment variables passed to the NORA container.
 env: {}


### PR DESCRIPTION
## Summary

- Render `[[docker.upstreams]]` from `values.yaml` into ConfigMap `config.toml`
- Add `existingSecret` option to mount registry credentials from a K8s Secret volume
- Docker proxy_timeout configurable via values

## Test plan

- `helm template` renders correctly with upstreams + existingSecret
- `helm template` renders correctly with defaults (no upstreams, no secret)