### PR TITLE
chore: bump nora chart to 0.1.8 (appVersion 0.6.3)

### DIFF
--- a/charts/nora/Chart.yaml
+++ b/charts/nora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nora
 description: NORA — a container registry proxy with caching and garbage collection
 type: application
-version: 0.1.7
-appVersion: "0.6.2"
+version: 0.1.8
+appVersion: "0.6.3"
 annotations:
   artifacthub.io/category: integration-delivery
 home: https://github.com/getnora-io/nora


### PR DESCRIPTION
Track NORA v0.6.3 release.

Changes in v0.6.3: coherence fixes, publish lock races, raw immutability, shared GC/Retention cleanup lock, expanded OpenAPI and docs. 633 tests.