### PR TITLE
add httproute support

### DIFF
--- a/charts/nora/templates/NOTES.txt
+++ b/charts/nora/templates/NOTES.txt
@@ -15,6 +15,10 @@ NORA has been installed.
 {{- range $host := .Values.ingress.hosts }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
 {{- end }}
+{{- else if .Values.httpRoute.enabled }}
+{{- range $host := .Values.httpRoute.hostnames }}
+  https://{{ $host }}
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "nora.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/nora/templates/httproute.yaml
+++ b/charts/nora/templates/httproute.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: {{ .Values.httpRoute.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ .Values.httpRoute.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ include "nora.fullname" . }}
+  labels:
+    {{- include "nora.labels" . | nindent 4 }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with .Values.httpRoute.extraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- range .Values.httpRoute.rules }}
+      {{- if .matches }}
+    - matches:
+        {{- toYaml .matches | nindent 8 }}
+      {{- else }}
+    -
+      {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "nora.fullname" $ }}
+          port: {{ $.Values.service.port }}
+          group: ""
+          kind: Service
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/charts/nora/templates/httproute.yaml
+++ b/charts/nora/templates/httproute.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.httpRoute.enabled -}}
-apiVersion: {{ .Values.httpRoute.apiVersion | default "gateway.networking.k8s.io/v1" }}
-kind: {{ .Values.httpRoute.kind | default "HTTPRoute" }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
   name: {{ include "nora.fullname" . }}
   labels:

--- a/charts/nora/values.yaml
+++ b/charts/nora/values.yaml
@@ -44,6 +44,26 @@ ingress:
   #    hosts:
   #      - registry.example.com
 
+httpRoute:
+  enabled: true
+  apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  annotations: {}
+  labels: {}
+  parentRefs: []
+  #  - name: shared-gateway
+  #    namespace: gateway-system
+  #    sectionName: http
+  hostnames:
+    - registry.example.com
+  extraRules: []
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters: []
+
 persistence:
   enabled: true
   size: 10Gi

--- a/charts/nora/values.yaml
+++ b/charts/nora/values.yaml
@@ -46,8 +46,6 @@ ingress:
 
 httpRoute:
   enabled: false
-  apiVersion: gateway.networking.k8s.io/v1
-  kind: HTTPRoute
   annotations: {}
   labels: {}
   parentRefs: []

--- a/charts/nora/values.yaml
+++ b/charts/nora/values.yaml
@@ -45,7 +45,7 @@ ingress:
   #      - registry.example.com
 
 httpRoute:
-  enabled: true
+  enabled: false
   apiVersion: gateway.networking.k8s.io/v1
   kind: HTTPRoute
   annotations: {}
@@ -54,8 +54,8 @@ httpRoute:
   #  - name: shared-gateway
   #    namespace: gateway-system
   #    sectionName: http
-  hostnames:
-    - registry.example.com
+  hostnames: []
+  #  - registry.example.com
   extraRules: []
   rules:
     - matches:


### PR DESCRIPTION
Add api gateway support, because ingress nginx is deprecated.
https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/