### PR TITLE
feat(nora): add public_url to chart config

### DIFF
--- a/charts/nora/Chart.yaml
+++ b/charts/nora/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nora
 description: NORA — a container registry proxy with caching and garbage collection
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.6.4"
 annotations:
   artifacthub.io/category: integration-delivery

--- a/charts/nora/templates/configmap.yaml
+++ b/charts/nora/templates/configmap.yaml
@@ -9,6 +9,9 @@ data:
     [server]
     host = {{ .Values.config.server.host | quote }}
     port = {{ .Values.config.server.port | default 4000 }}
+    {{- if .Values.config.server.public_url }}
+    public_url = {{ .Values.config.server.public_url | quote }}
+    {{- end }}
 
     [storage]
     mode = {{ .Values.config.storage.mode | quote }}

--- a/charts/nora/values.yaml
+++ b/charts/nora/values.yaml
@@ -74,6 +74,10 @@ config:
   server:
     host: "0.0.0.0"
     port: 4000
+    # -- Public URL for UI install commands and auth realm.
+    # Set this when NORA is behind Ingress/reverse proxy.
+    # Example: "https://registry.example.com"
+    public_url: ""
   storage:
     mode: local
     path: /data/storage


### PR DESCRIPTION
## Summary
- Adds `config.server.public_url` as a first-class field in `values.yaml`
- Renders `public_url` in configmap only when set (no empty string in TOML)
- Chart version bump: 0.2.1 → 0.2.2

## Context
Issue getnora-io/nora#177 revealed that `NORA_PUBLIC_URL` was not surfaced in the Helm chart. Users had to use `extraEnv` workaround. Now:

\`\`\`yaml
config:
  server:
    public_url: "https://registry.example.com"
\`\`\`

## Backwards compatible
- Default is empty string → field not rendered → no behavior change
- extraEnv with NORA_PUBLIC_URL still works (env var overrides config.toml)
- appVersion stays at 0.6.4

## Test plan
- [x] helm template renders correctly with and without public_url
- [x] S3, existingSecret, extraEnv all render correctly