### PR TITLE
chore: bump chart 0.2.3, appVersion 0.6.5

### DIFF
--- a/charts/nora/Chart.yaml
+++ b/charts/nora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nora
 description: NORA — a container registry proxy with caching and garbage collection
 type: application
-version: 0.2.2
-appVersion: "0.6.4"
+version: 0.2.3
+appVersion: "0.6.5"
 annotations:
   artifacthub.io/category: integration-delivery
 home: https://github.com/getnora-io/nora


### PR DESCRIPTION
## Summary
- Chart version 0.2.2 → 0.2.3
- appVersion 0.6.4 → 0.6.5

NORA v0.6.5 fixes `NORA_PUBLIC_URL` being ignored in UI install commands and Docker auth realm (#177).