### PR TITLE
feat: auto-derive public_url from ingress/httpRoute

### DIFF
--- a/charts/nora/Chart.yaml
+++ b/charts/nora/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nora
 description: NORA — a container registry proxy with caching and garbage collection
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: "0.6.5"
 annotations:
   artifacthub.io/category: integration-delivery

--- a/charts/nora/templates/configmap.yaml
+++ b/charts/nora/templates/configmap.yaml
@@ -11,6 +11,12 @@ data:
     port = {{ .Values.config.server.port | default 4000 }}
     {{- if .Values.config.server.public_url }}
     public_url = {{ .Values.config.server.public_url | quote }}
+    {{- else if and .Values.ingress.enabled .Values.ingress.hosts }}
+    {{- $host := (index .Values.ingress.hosts 0).host }}
+    {{- $scheme := ternary "https" "http" (gt (len .Values.ingress.tls) 0) }}
+    public_url = {{ printf "%s://%s" $scheme $host | quote }}
+    {{- else if and .Values.httpRoute.enabled .Values.httpRoute.hostnames }}
+    public_url = {{ printf "https://%s" (index .Values.httpRoute.hostnames 0) | quote }}
     {{- end }}
 
     [storage]

--- a/charts/nora/values.yaml
+++ b/charts/nora/values.yaml
@@ -75,7 +75,8 @@ config:
     host: "0.0.0.0"
     port: 4000
     # -- Public URL for UI install commands and auth realm.
-    # Set this when NORA is behind Ingress/reverse proxy.
+    # Auto-derived from ingress/httpRoute if empty.
+    # Set explicitly for non-standard setups (CDN, reverse proxy, NodePort).
     # Example: "https://registry.example.com"
     public_url: ""
   storage:


### PR DESCRIPTION
## Summary
- Auto-derive `public_url` from `ingress.hosts[0]` or `httpRoute.hostnames[0]` when not set explicitly
- Scheme: `https` if `ingress.tls` is configured, `http` otherwise. httpRoute assumes `https`
- Explicit `config.server.public_url` always takes precedence
- Chart version 0.2.3 → 0.2.4

## Test plan
Tested on dev K8s (3 nodes, v1.31.4):
- [x] No ingress, no public_url → not set
- [x] Ingress + TLS → `https://host`
- [x] Ingress no TLS → `http://host`
- [x] Explicit + ingress → explicit wins
- [x] Health: all 7 registries ok
- [x] `helm lint` pass
- [x] `helm template` all scenarios verified

Closes #6