### PR TITLE
chore: chart v0.3.0 — appVersion 0.7.0

### DIFF
--- a/charts/nora/Chart.yaml
+++ b/charts/nora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nora
 description: NORA — a container registry proxy with caching and garbage collection
 type: application
-version: 0.2.4
-appVersion: "0.6.5"
+version: 0.3.0
+appVersion: "0.7.0"
 annotations:
   artifacthub.io/category: integration-delivery
 home: https://github.com/getnora-io/nora


### PR DESCRIPTION
## Summary
- Bump chart version `0.2.4` → `0.3.0`
- Bump appVersion `0.6.5` → `0.7.0`

NORA v0.7.0 release: https://github.com/getnora-io/nora/releases/tag/v0.7.0