### PR TITLE
chore: bump chart v0.3.1, appVersion 0.7.1

### DIFF
--- a/charts/nora/Chart.yaml
+++ b/charts/nora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nora
 description: NORA — a container registry proxy with caching and garbage collection
 type: application
-version: 0.3.0
-appVersion: "0.7.0"
+version: 0.3.1
+appVersion: "0.7.1"
 annotations:
   artifacthub.io/category: integration-delivery
 home: https://github.com/getnora-io/nora


### PR DESCRIPTION
Bump for NORA v0.7.1 release:
- Min-release-age curation filter
- Token RBAC UI polish  
- Dynamic stats footer

Depends on: https://github.com/getnora-io/nora/pull/202