### PR TITLE
chore: bump appVersion to 0.8.0

### DIFF
--- a/charts/nora/Chart.yaml
+++ b/charts/nora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nora
 description: NORA — a container registry proxy with caching and garbage collection
 type: application
-version: 0.3.3
-appVersion: "0.7.2"
+version: 0.3.4
+appVersion: "0.8.0"
 annotations:
   artifacthub.io/category: integration-delivery
 home: https://github.com/getnora-io/nora


### PR DESCRIPTION
## Summary
- Bump chart version 0.3.3 → 0.3.4
- Bump appVersion 0.7.2 → 0.8.0