### PR TITLE
chore(nora): bump appVersion to 0.8.2

### DIFF
--- a/charts/nora/Chart.yaml
+++ b/charts/nora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nora
 description: NORA — a container registry proxy with caching and garbage collection
 type: application
-version: 0.3.4
-appVersion: "0.8.0"
+version: 0.3.5
+appVersion: "0.8.2"
 annotations:
   artifacthub.io/category: integration-delivery
 home: https://github.com/getnora-io/nora


### PR DESCRIPTION
## Summary

- Bump `appVersion` from 0.8.0 to 0.8.2
- Bump chart `version` from 0.3.4 to 0.3.5

Tracks NORA [v0.8.1](https://github.com/getnora-io/nora/releases/tag/v0.8.1) and [v0.8.2](https://github.com/getnora-io/nora/releases/tag/v0.8.2) releases.