### PR TITLE
ci: handle existing branch in appVersion bump workflow

### DIFF
--- a/.github/workflows/bump-appversion.yml
+++ b/.github/workflows/bump-appversion.yml
@@ -58,7 +58,14 @@ jobs:
           git checkout -b "$BRANCH"
           git add charts/nora/Chart.yaml
           git commit -m "chore(nora): bump appVersion to ${{ steps.bump.outputs.new_app }}"
-          git push origin "$BRANCH"
+          git push --force origin "$BRANCH"
+
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number -q '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists, updating"
+            gh pr merge --auto --squash "$BRANCH" || true
+            exit 0
+          fi
 
           gh pr create \
             --title "chore(nora): bump appVersion to ${{ steps.bump.outputs.new_app }}" \


### PR DESCRIPTION
Force-push branch if it already exists, reuse existing PR instead of failing.