### PR TITLE
fix: use workflow_run trigger for auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,8 +1,9 @@
 name: Auto-merge trusted contributors
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["Lint and Test Charts"]
+    types: [completed]
 
 permissions:
   contents: write
@@ -11,10 +12,18 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: contains(fromJSON('["makavity", "mit-73"]'), github.event.pull_request.user.login)
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      contains(fromJSON('["makavity", "mit-73"]'), github.event.workflow_run.actor.login)
     steps:
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "0" ]; then
+            echo "No PR found in workflow_run payload, skipping"
+            exit 0
+          fi
+          gh pr merge --auto --squash "$PR_NUMBER" --repo "${{ github.repository }}"
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Auto-merge workflow was failing with `Pull request is in unstable status` because `pull_request_target` creates a check run on the PR, which blocks `enablePullRequestAutoMerge`
- Switched to `workflow_run` trigger that fires after "Lint and Test Charts" completes — no check run on the PR, no circular dependency
- Added guards: only runs on `success` conclusion, only for `pull_request` events (not push to main), only for trusted contributors

## What changed
- Trigger: `pull_request_target` → `workflow_run` (after CI)
- PR number: from `workflow_run.pull_requests[0].number` instead of `pull_request.html_url`
- Added `conclusion == 'success'` check — won't auto-merge if CI fails