### PR TITLE
chore(nora): bump appVersion to 0.9.0

### DIFF
--- a/charts/nora/Chart.yaml
+++ b/charts/nora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nora
 description: NORA — a container registry proxy with caching and garbage collection
 type: application
-version: 0.3.7
-appVersion: "0.8.4"
+version: 0.3.8
+appVersion: "0.9.0"
 annotations:
   artifacthub.io/category: integration-delivery
 home: https://github.com/getnora-io/nora


### PR DESCRIPTION
Automated bump triggered by NORA v0.9.0 release.

- `appVersion` → `0.9.0`
- Chart version bumped accordingly

Workflow `nora-release` pushed the branch but couldn't create the PR due to missing repository permission ("Allow GitHub Actions to create and approve pull requests").

**Fix needed:** Settings → Actions → General → enable "Allow GitHub Actions to create and approve pull requests"