### PR TITLE
chore(nora): Add `.gitignore`, authentication config, and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: azure/setup-helm@v4
 
       - name: Install helm-unittest
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.0
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.0 --verify=false
 
       - name: Helm lint
         run: helm lint charts/nora/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,17 +27,29 @@ jobs:
 
       - uses: azure/setup-helm@v4
 
+      - name: Install helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.0
+
       - name: Helm lint
         run: helm lint charts/nora/
+
+      - name: Chart unit tests
+        run: helm unittest charts/nora
 
       - name: Helm template (defaults)
         run: helm template nora charts/nora/ > /dev/null
 
-      - name: Helm template (ingress + secrets)
+      - name: Helm template (auth + ingress)
         run: |
           helm template nora charts/nora/ \
             --set ingress.enabled=true \
-            --set secrets.TEST_KEY=test \
+            --set ingress.tls[0].secretName=registry-tls \
+            --set ingress.hosts[0].host=registry.example.com \
+            --set ingress.hosts[0].paths[0].path=/ \
+            --set ingress.hosts[0].paths[0].pathType=Prefix \
+            --set config.auth.enabled=true \
+            --set config.auth.htpasswd.existingSecret=nora-htpasswd \
+            --set existingSecret=nora-secrets \
             --set persistence.enabled=false > /dev/null
 
       - name: Helm template (registries selection)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,121 @@
+### VisualStudioCode template
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+

--- a/charts/nora/README.md
+++ b/charts/nora/README.md
@@ -87,6 +87,82 @@ config:
     general_burst: 200
 ```
 
+### Authentication
+
+Maps to `[auth]` (and optionally `[auth.oidc]`) in `config.toml`.
+
+#### Basic auth (htpasswd)
+
+Create a bcrypt htpasswd file locally, then store it in a Secret:
+
+```bash
+htpasswd -Bc /tmp/users.htpasswd admin
+kubectl create secret generic nora-htpasswd \
+  --from-file=users.htpasswd=/tmp/users.htpasswd
+```
+
+```yaml
+config:
+  auth:
+    enabled: true
+    token_storage: data/tokens
+    anonymous_read: false
+    htpasswd:
+      existingSecret: nora-htpasswd
+```
+
+The chart mounts the Secret at `/etc/nora/users.htpasswd` and sets `htpasswd_file` in `config.toml` automatically. Override the path with `config.auth.htpasswd_file` if needed.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `config.auth.enabled` | Enable authentication | `false` |
+| `config.auth.htpasswd_file` | Explicit htpasswd path in the container | `""` (auto when Secret is set) |
+| `config.auth.anonymous_read` | Allow unauthenticated reads | `false` |
+| `config.auth.token_storage` | API token storage path | `data/tokens` |
+| `config.auth.htpasswd.existingSecret` | Secret with htpasswd file | `""` |
+| `config.auth.htpasswd.secretKey` | Key in the Secret | `users.htpasswd` |
+| `config.auth.htpasswd.mountPath` | Mount directory | `/etc/nora` |
+
+#### OIDC
+
+Role rules use glob patterns on the JWT `sub` claim; first match wins.
+
+```yaml
+config:
+  auth:
+    enabled: true
+    anonymous_read: false
+    oidc:
+      enabled: true
+      leeway_secs: 60
+      jwks_cache_secs: 300
+      providers:
+        - name: github-actions
+          issuer: https://token.actions.githubusercontent.com
+          audience: nora
+          algorithms:
+            - RS256
+            - ES256
+          max_token_lifetime_secs: 900
+          enabled: true
+          role_rules:
+            - pattern: "repo:myorg/*:ref:refs/heads/main"
+              role: write
+            - pattern: "repo:myorg/*"
+              role: read
+```
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `config.auth.oidc.enabled` | Enable OIDC JWT auth | `false` |
+| `config.auth.oidc.leeway_secs` | Clock skew tolerance (seconds) | `60` |
+| `config.auth.oidc.jwks_cache_secs` | JWKS cache TTL (seconds) | `300` |
+| `config.auth.oidc.providers` | OIDC provider list | `[]` |
+
+Per provider: `name`, `issuer`, `audience`, `algorithms`, `max_token_lifetime_secs`, `enabled`, optional `jwks_uri`, and `role_rules` (`pattern`, `role`).
+
+You can still use `NORA_AUTH_*` env vars via `extraEnv`; they take precedence over `config.toml` when set.
+
 ### Rate limiting
 
 Maps to NORA’s `[rate_limit]` in `config.toml`. Tuning guide: [Rate limits configuration](https://getnora.dev/configuration/rate-limits/).
@@ -231,6 +307,30 @@ config:
 - `conan`
 
 ## Testing
+
+### Unit tests (helm-unittest)
+
+```bash
+helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.0
+helm unittest charts/nora
+```
+
+Tests live in `charts/nora/tests/`:
+
+| Suite | Coverage |
+|-------|----------|
+| `configmap_test.yaml` | `config.toml`: auth, OIDC, S3, docker upstreams, retention, rate limits, `public_url` |
+| `deployment_test.yaml` | image, probes, volumes, env, scheduling, service account |
+| `service_test.yaml` | Service type, port, naming |
+| `ingress_test.yaml` | Ingress rules, TLS, annotations |
+| `httproute_test.yaml` | Gateway API HTTPRoute |
+| `pvc_test.yaml` | persistence on/off, storage class |
+| `serviceaccount_test.yaml` | create/skip, annotations |
+| `test_connection_test.yaml` | `helm test` hook pod |
+
+### Post-install hook
+
+After deploying to a cluster:
 
 ```bash
 helm test nora

--- a/charts/nora/README.md
+++ b/charts/nora/README.md
@@ -311,7 +311,7 @@ config:
 ### Unit tests (helm-unittest)
 
 ```bash
-helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.0
+helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.0 --verify=false
 helm unittest charts/nora
 ```
 

--- a/charts/nora/templates/_helpers.tpl
+++ b/charts/nora/templates/_helpers.tpl
@@ -60,9 +60,23 @@ Create the name of the service account to use.
 {{- end }}
 
 {{/*
-Image reference.
+Image reference. Tag defaults to Chart.appVersion; set image.tag to override.
 */}}
 {{- define "nora.image" -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag }}
+{{- $tag := .Chart.AppVersion }}
+{{- if .Values.image.tag }}
+{{- $tag = .Values.image.tag }}
+{{- end }}
 {{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}
+
+{{/*
+Resolved htpasswd file path for config.toml (explicit htpasswd_file or Secret mount).
+*/}}
+{{- define "nora.auth.htpasswdFile" -}}
+{{- if .Values.config.auth.htpasswd_file }}
+{{- .Values.config.auth.htpasswd_file }}
+{{- else if .Values.config.auth.htpasswd.existingSecret }}
+{{- printf "%s/%s" .Values.config.auth.htpasswd.mountPath (.Values.config.auth.htpasswd.secretKey | default "users.htpasswd") }}
+{{- end }}
 {{- end }}

--- a/charts/nora/templates/configmap.yaml
+++ b/charts/nora/templates/configmap.yaml
@@ -68,6 +68,46 @@ data:
     {{- end }}
     {{- end }}
 
+    {{- if .Values.config.auth.enabled }}
+    {{- $htpasswdFile := include "nora.auth.htpasswdFile" . }}
+
+    [auth]
+    enabled = {{ .Values.config.auth.enabled }}
+    {{- if $htpasswdFile }}
+    htpasswd_file = {{ $htpasswdFile | quote }}
+    {{- end }}
+    token_storage = {{ .Values.config.auth.token_storage | quote }}
+    anonymous_read = {{ .Values.config.auth.anonymous_read }}
+    {{- if .Values.config.auth.oidc.enabled }}
+
+    [auth.oidc]
+    enabled = {{ .Values.config.auth.oidc.enabled }}
+    leeway_secs = {{ .Values.config.auth.oidc.leeway_secs }}
+    jwks_cache_secs = {{ .Values.config.auth.oidc.jwks_cache_secs }}
+    {{- range .Values.config.auth.oidc.providers }}
+
+    [[auth.oidc.providers]]
+    name = {{ .name | quote }}
+    issuer = {{ .issuer | quote }}
+    audience = {{ .audience | quote }}
+    {{- if .algorithms }}
+    algorithms = [{{- range $i, $v := .algorithms }}{{- if $i }}, {{ end }}{{ $v | quote }}{{- end }}]
+    {{- end }}
+    max_token_lifetime_secs = {{ .max_token_lifetime_secs }}
+    enabled = {{ .enabled | default true }}
+    {{- if .jwks_uri }}
+    jwks_uri = {{ .jwks_uri | quote }}
+    {{- end }}
+    {{- range .role_rules }}
+
+    [[auth.oidc.providers.role_rules]]
+    pattern = {{ .pattern | quote }}
+    role = {{ .role | quote }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+
     [rate_limit]
     enabled = {{ .Values.config.rate_limit.enabled }}
     {{- if .Values.config.rate_limit.enabled }}

--- a/charts/nora/templates/deployment.yaml
+++ b/charts/nora/templates/deployment.yaml
@@ -80,6 +80,11 @@ spec:
               mountPath: /config/secrets
               readOnly: true
             {{- end }}
+            {{- if .Values.config.auth.htpasswd.existingSecret }}
+            - name: htpasswd
+              mountPath: {{ .Values.config.auth.htpasswd.mountPath }}
+              readOnly: true
+            {{- end }}
             - name: data
               mountPath: /data
             - name: tmp
@@ -92,6 +97,14 @@ spec:
         - name: secrets-config
           secret:
             secretName: {{ .Values.existingSecret }}
+        {{- end }}
+        {{- if .Values.config.auth.htpasswd.existingSecret }}
+        - name: htpasswd
+          secret:
+            secretName: {{ .Values.config.auth.htpasswd.existingSecret }}
+            items:
+              - key: {{ .Values.config.auth.htpasswd.secretKey }}
+                path: {{ .Values.config.auth.htpasswd.secretKey }}
         {{- end }}
         - name: data
           {{- if .Values.persistence.enabled }}

--- a/charts/nora/tests/configmap_test.yaml
+++ b/charts/nora/tests/configmap_test.yaml
@@ -1,0 +1,299 @@
+suite: configmap
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: renders default config without auth section
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '^\[server\]'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: '\[auth\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[rate_limit\]'
+
+  - it: renders auth with htpasswd and anonymous_read
+    set:
+      config.auth.enabled: true
+      config.auth.anonymous_read: true
+      config.auth.htpasswd.existingSecret: nora-htpasswd
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[auth\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'enabled = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'htpasswd_file = "/etc/nora/users\.htpasswd"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'token_storage = "data/tokens"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'anonymous_read = true'
+
+  - it: renders explicit htpasswd_file path
+    set:
+      config.auth.enabled: true
+      config.auth.htpasswd_file: /data/users.htpasswd
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'htpasswd_file = "/data/users\.htpasswd"'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: '/etc/nora/users\.htpasswd'
+
+  - it: renders OIDC providers and role rules
+    set:
+      config.auth.enabled: true
+      config.auth.oidc.enabled: true
+      config.auth.oidc.providers:
+        - name: github-actions
+          issuer: https://token.actions.githubusercontent.com
+          audience: nora
+          algorithms:
+            - RS256
+            - ES256
+          max_token_lifetime_secs: 900
+          enabled: true
+          role_rules:
+            - pattern: "repo:myorg/*:ref:refs/heads/main"
+              role: write
+            - pattern: "repo:myorg/*"
+              role: read
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[auth\.oidc\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'name = "github-actions"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'pattern = "repo:myorg/\*:ref:refs/heads/main"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'role = "write"'
+
+  - it: derives public_url from ingress with TLS
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: registry.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      ingress.tls:
+        - secretName: registry-tls
+          hosts:
+            - registry.example.com
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'public_url = "https://registry\.example\.com"'
+
+  - it: renders registries as a list
+    set:
+      config.registries.enable:
+        - docker
+        - npm
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'enable = \["docker", "npm"\]'
+
+  - it: omits rate limit tuning when disabled
+    set:
+      config.rate_limit.enabled: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[rate_limit\]\nenabled = false'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'auth_rps'
+
+  - it: renders explicit public_url
+    set:
+      config.server.public_url: https://cdn.example.com/registry
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'public_url = "https://cdn\.example\.com/registry"'
+
+  - it: derives public_url from HTTPRoute hostnames
+    set:
+      httpRoute.enabled: true
+      httpRoute.hostnames:
+        - registry.example.com
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'public_url = "https://registry\.example\.com"'
+
+  - it: derives public_url from ingress without TLS
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: registry.local
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'public_url = "http://registry\.local"'
+
+  - it: renders registries enable all string
+    set:
+      config.registries.enable: all
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'enable = "all"'
+
+  - it: renders S3 storage settings
+    set:
+      config.storage.mode: s3
+      config.storage.s3_url: https://s3.amazonaws.com
+      config.storage.bucket: my-bucket
+      config.storage.s3_region: eu-west-1
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'mode = "s3"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 's3_url = "https://s3\.amazonaws\.com"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'bucket = "my-bucket"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 's3_region = "eu-west-1"'
+
+  - it: renders docker upstreams
+    set:
+      config.docker.upstreams:
+        - url: https://registry-1.docker.io
+        - url: https://private.registry.io
+          auth: user:token
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[\[docker\.upstreams\]\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'url = "https://registry-1\.docker\.io"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'auth = "user:token"'
+
+  - it: renders retention rules
+    set:
+      config.retention.enabled: true
+      config.retention.rules:
+        - registry: docker
+          max_age_days: 30
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'enabled = true'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[\[retention\.rules\]\]'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'registry = "docker"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'max_age_days = "30"'
+
+  - it: renders auth without htpasswd_file when not configured
+    set:
+      config.auth.enabled: true
+      config.auth.anonymous_read: false
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'anonymous_read = false'
+      - notMatchRegex:
+          path: data["config.toml"]
+          pattern: 'htpasswd_file'
+
+  - it: renders OIDC jwks_uri override
+    set:
+      config.auth.enabled: true
+      config.auth.oidc.enabled: true
+      config.auth.oidc.providers:
+        - name: custom-idp
+          issuer: https://auth.internal.corp
+          audience: nora
+          algorithms:
+            - RS256
+          max_token_lifetime_secs: 3600
+          jwks_uri: https://auth.internal.corp/keys/jwks.json
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'jwks_uri = "https://auth\.internal\.corp/keys/jwks\.json"'
+
+  - it: renders custom htpasswd secret mount path
+    set:
+      config.auth.enabled: true
+      config.auth.htpasswd.existingSecret: my-htpasswd
+      config.auth.htpasswd.secretKey: htpasswd
+      config.auth.htpasswd.mountPath: /secrets/auth
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'htpasswd_file = "/secrets/auth/htpasswd"'
+
+  - it: renders gc and retention defaults
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[gc\]\nenabled = true\ninterval = 86400'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[retention\]\nenabled = false'
+
+  - it: combines htpasswd and OIDC in one auth block
+    set:
+      config.auth.enabled: true
+      config.auth.htpasswd.existingSecret: nora-htpasswd
+      config.auth.oidc.enabled: true
+      config.auth.oidc.providers:
+        - name: github-actions
+          issuer: https://token.actions.githubusercontent.com
+          audience: nora
+          algorithms:
+            - RS256
+          max_token_lifetime_secs: 900
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'htpasswd_file = "/etc/nora/users\.htpasswd"'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: '\[auth\.oidc\]'
+
+  - it: renders rate limit tuning when enabled
+    set:
+      config.rate_limit.enabled: true
+      config.rate_limit.auth_rps: 2
+      config.rate_limit.general_burst: 300
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'auth_rps = 2'
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'general_burst = 300'

--- a/charts/nora/tests/deployment_test.yaml
+++ b/charts/nora/tests/deployment_test.yaml
@@ -1,0 +1,280 @@
+suite: deployment
+templates:
+  - templates/deployment.yaml
+  - templates/configmap.yaml
+tests:
+  - it: renders a Deployment with default volumes
+    template: templates/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: NORA_CONFIG_PATH
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /config
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: htpasswd
+
+  - it: mounts htpasswd secret when configured
+    template: templates/deployment.yaml
+    set:
+      config.auth.htpasswd.existingSecret: nora-htpasswd
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: htpasswd
+            mountPath: /etc/nora
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: htpasswd
+            secret:
+              secretName: nora-htpasswd
+              items:
+                - key: users.htpasswd
+                  path: users.htpasswd
+
+  - it: mounts existingSecret for docker upstream credentials
+    template: templates/deployment.yaml
+    set:
+      existingSecret: nora-secrets
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secrets-config
+            mountPath: /config/secrets
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secrets-config
+            secret:
+              secretName: nora-secrets
+
+  - it: uses emptyDir for data when persistence is disabled
+    template: templates/deployment.yaml
+    set:
+      persistence.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+
+  - it: uses PVC for data when persistence is enabled
+    template: templates/deployment.yaml
+    set:
+      persistence.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-nora-data
+
+  - it: uses custom image tag
+    template: templates/deployment.yaml
+    set:
+      image.tag: 0.9.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/getnora-io/nora:0.9.0
+
+  - it: uses chart appVersion when image tag is empty
+    template: templates/deployment.yaml
+    chart:
+      appVersion: "9.8.7"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/getnora-io/nora:9.8.7
+
+  - it: sets replicaCount
+    template: templates/deployment.yaml
+    set:
+      replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: injects extraEnv and extraEnvFrom
+    template: templates/deployment.yaml
+    set:
+      extraEnv:
+        - name: NORA_AUTH_ENABLED
+          value: "true"
+      extraEnvFrom:
+        - secretRef:
+            name: nora-env
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NORA_AUTH_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: nora-env
+
+  - it: applies pod scheduling fields
+    template: templates/deployment.yaml
+    set:
+      nodeSelector:
+        disktype: ssd
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: registry
+          effect: NoSchedule
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: []
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.disktype
+          value: ssd
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: registry
+            effect: NoSchedule
+      - isNotNull:
+          path: spec.template.spec.affinity.podAntiAffinity
+
+  - it: applies security context and probes
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /ready
+
+  - it: uses custom server port
+    template: templates/deployment.yaml
+    set:
+      config.server.port: 8080
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+
+  - it: mounts custom htpasswd secret key
+    template: templates/deployment.yaml
+    set:
+      config.auth.htpasswd.existingSecret: my-htpasswd
+      config.auth.htpasswd.secretKey: htpasswd
+      config.auth.htpasswd.mountPath: /secrets/auth
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: htpasswd
+            secret:
+              secretName: my-htpasswd
+              items:
+                - key: htpasswd
+                  path: htpasswd
+
+  - it: includes config checksum annotation
+    template: templates/deployment.yaml
+    asserts:
+      - isNotEmpty:
+          path: spec.template.metadata.annotations.checksum/config
+
+  - it: uses default service account when create is true
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-nora
+
+  - it: uses custom service account name
+    template: templates/deployment.yaml
+    set:
+      serviceAccount.name: external-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: external-sa
+
+  - it: applies imagePullSecrets and resources
+    template: templates/deployment.yaml
+    set:
+      imagePullSecrets:
+        - name: ghcr-credentials
+      resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: ghcr-credentials
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1Gi
+
+  - it: applies pod labels and annotations
+    template: templates/deployment.yaml
+    set:
+      podLabels:
+        app: nora
+      podAnnotations:
+        prometheus.io/scrape: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: nora
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: mounts htpasswd and secrets together
+    template: templates/deployment.yaml
+    set:
+      config.auth.htpasswd.existingSecret: nora-htpasswd
+      existingSecret: nora-secrets
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: htpasswd
+            mountPath: /etc/nora
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secrets-config
+            mountPath: /config/secrets
+            readOnly: true

--- a/charts/nora/tests/httproute_test.yaml
+++ b/charts/nora/tests/httproute_test.yaml
@@ -1,0 +1,39 @@
+suite: httproute
+templates:
+  - templates/httproute.yaml
+tests:
+  - it: does not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders HTTPRoute with hostnames and parentRefs
+    set:
+      httpRoute.enabled: true
+      httpRoute.hostnames:
+        - registry.example.com
+      httpRoute.parentRefs:
+        - name: shared-gateway
+          namespace: gateway-system
+      httpRoute.labels:
+        team: platform
+      httpRoute.annotations:
+        external-dns.alpha.kubernetes.io/hostname: registry.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.hostnames[0]
+          value: registry.example.com
+      - equal:
+          path: spec.parentRefs[0].name
+          value: shared-gateway
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-nora
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 4000

--- a/charts/nora/tests/ingress_test.yaml
+++ b/charts/nora/tests/ingress_test.yaml
@@ -1,0 +1,66 @@
+suite: ingress
+templates:
+  - templates/ingress.yaml
+tests:
+  - it: does not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders ingress with class and TLS
+    set:
+      ingress.enabled: true
+      ingress.className: nginx
+      ingress.annotations:
+        cert-manager.io/cluster-issuer: letsencrypt
+      ingress.hosts:
+        - host: registry.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      ingress.tls:
+        - secretName: registry-tls
+          hosts:
+            - registry.example.com
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt
+      - equal:
+          path: spec.tls[0].secretName
+          value: registry-tls
+      - equal:
+          path: spec.rules[0].host
+          value: registry.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-nora
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+          value: http
+
+  - it: supports multiple paths per host
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: registry.example.com
+          paths:
+            - path: /v2
+              pathType: Prefix
+            - path: /ui
+              pathType: Prefix
+    asserts:
+      - lengthEqual:
+          path: spec.rules[0].http.paths
+          count: 2
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /v2
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: /ui

--- a/charts/nora/tests/pvc_test.yaml
+++ b/charts/nora/tests/pvc_test.yaml
@@ -1,0 +1,41 @@
+suite: pvc
+templates:
+  - templates/pvc.yaml
+tests:
+  - it: renders PVC with defaults
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-nora-data
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+
+  - it: does not render when persistence is disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: supports custom size and storageClass
+    set:
+      persistence.size: 50Gi
+      persistence.storageClass: fast-ssd
+      persistence.annotations:
+        volume.beta.kubernetes.io/storage-class: fast-ssd
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 50Gi
+      - equal:
+          path: spec.storageClassName
+          value: fast-ssd
+      - equal:
+          path: metadata.annotations["volume.beta.kubernetes.io/storage-class"]
+          value: fast-ssd

--- a/charts/nora/tests/service_test.yaml
+++ b/charts/nora/tests/service_test.yaml
@@ -1,0 +1,43 @@
+suite: service
+templates:
+  - templates/service.yaml
+tests:
+  - it: renders ClusterIP service by default
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-nora
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 4000
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: nora
+
+  - it: supports NodePort service type
+    set:
+      service.type: NodePort
+      service.port: 8080
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+
+  - it: uses fullnameOverride for resource name
+    set:
+      fullnameOverride: my-registry
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-registry

--- a/charts/nora/tests/serviceaccount_test.yaml
+++ b/charts/nora/tests/serviceaccount_test.yaml
@@ -1,0 +1,35 @@
+suite: serviceaccount
+templates:
+  - templates/serviceaccount.yaml
+tests:
+  - it: renders ServiceAccount by default
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-nora
+
+  - it: does not render when create is false
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: uses custom service account name
+    set:
+      serviceAccount.name: nora-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: nora-sa
+
+  - it: applies annotations
+    set:
+      serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/nora
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123456789012:role/nora

--- a/charts/nora/tests/test_connection_test.yaml
+++ b/charts/nora/tests/test_connection_test.yaml
@@ -1,0 +1,20 @@
+suite: test connection hook
+templates:
+  - templates/tests/test-connection.yaml
+tests:
+  - it: renders helm test pod targeting service health
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+      - equal:
+          path: spec.restartPolicy
+          value: Never
+      - equal:
+          path: spec.containers[0].image
+          value: busybox:1.36
+      - contains:
+          path: spec.containers[0].args
+          content: RELEASE-NAME-nora:4000/health

--- a/charts/nora/values.yaml
+++ b/charts/nora/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/getnora-io/nora
-  # -- Overrides the image tag. Defaults to Chart.appVersion.
+  # -- Image tag. Leave empty to use Chart.appVersion (recommended).
   tag: ""
   pullPolicy: IfNotPresent
 
@@ -105,6 +105,45 @@ config:
     enabled: false
     interval: 86400
     rules: []
+
+  # -- Authentication. Maps to [auth] and [auth.oidc] in config.toml.
+  auth:
+    enabled: false
+    # -- Basic auth via htpasswd file. Set explicitly or leave empty when using htpasswd.existingSecret.
+    htpasswd_file: ""
+    # -- Allow unauthenticated read (pull/browse); writes still require auth.
+    anonymous_read: false
+    # -- API token storage path (under /data when relative).
+    token_storage: "data/tokens"
+    # -- Mount htpasswd credentials from an existing Secret (recommended).
+    htpasswd:
+      existingSecret: ""
+      # -- Secret key containing the htpasswd file body.
+      secretKey: users.htpasswd
+      # -- Directory where the Secret key is mounted as a file.
+      mountPath: /etc/nora
+    oidc:
+      enabled: false
+      # -- Clock skew tolerance for JWT validation.
+      leeway_secs: 60
+      # -- JWKS key cache TTL.
+      jwks_cache_secs: 300
+      providers: []
+      # Example (GitHub Actions OIDC; set anonymous_read: true for public pulls):
+      #  - name: github-actions
+      #    issuer: https://token.actions.githubusercontent.com
+      #    audience: nora
+      #    algorithms:
+      #      - RS256
+      #      - ES256
+      #    max_token_lifetime_secs: 900
+      #    enabled: true
+      #    # jwks_uri: https://...  # optional JWKS endpoint override
+      #    role_rules:
+      #      - pattern: "repo:myorg/*:ref:refs/heads/main"
+      #        role: write
+      #      - pattern: "repo:myorg/*"
+      #        role: read
 
   # -- Rate limiting (token bucket). See https://getnora.dev/configuration/rate-limits/
   # Env overrides (NORA_RATE_LIMIT_*) still apply if set via extraEnv.


### PR DESCRIPTION
* Add `.gitignore` for common IDEs and environments.
* Extend `values.yaml` with authentication settings (basic auth, OIDC).
* Update `configmap.yaml` to include `[auth]` and `[auth.oidc]` sections.
* Add unit tests for `configmap`, `pvc`, `ingress`, `httproute`, and more.
* Update `README.md` with authentication setup instructions and test information.