### PR TITLE
fix(release): bump chart to 0.3.9, add skip_existing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,5 +27,7 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
+        with:
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/nora/Chart.yaml
+++ b/charts/nora/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nora
 description: NORA — a container registry proxy with caching and garbage collection
 type: application
-version: 0.3.8
+version: 0.3.9
 appVersion: "0.9.0"
 annotations:
   artifacthub.io/category: integration-delivery


### PR DESCRIPTION
## Summary
- Bump chart version `0.3.8` → `0.3.9` (PR #20 added auth config + tests without a version bump)
- Add `skip_existing: true` to chart-releaser so doc/test-only commits without a version bump don't break the release pipeline

Fixes https://github.com/getnora-io/helm-charts/actions/runs/26151007898