### PR TITLE
docs: update Chart description, keywords, add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 The NORA Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/charts/nora/Chart.yaml
+++ b/charts/nora/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: nora
-description: NORA — a container registry proxy with caching and garbage collection
+description: NORA — lightweight multi-format artifact registry (Docker, Maven, npm, PyPI, Cargo, NuGet, and more)
 type: application
-version: 0.3.10
+version: 0.3.11
 appVersion: "0.9.1"
 annotations:
   artifacthub.io/category: integration-delivery
@@ -15,9 +15,13 @@ maintainers:
 icon: https://avatars.githubusercontent.com/u/257139033?v=4
 keywords:
   - registry
-  - container
+  - artifact-registry
   - proxy
   - cache
   - oci
-  - artifacts
   - docker
+  - maven
+  - npm
+  - pypi
+  - cargo
+  - nuget


### PR DESCRIPTION
## Summary
- Chart description: "container registry proxy" → "multi-format artifact registry"
- Keywords: add maven, npm, pypi, cargo, nuget, artifact-registry
- Add MIT LICENSE file
- Bump chart version to 0.3.11