### PR TITLE
chore(nora): bump appVersion to 0.9.3

### DIFF
--- a/charts/nora/Chart.yaml
+++ b/charts/nora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nora
 description: NORA — lightweight multi-format artifact registry (Docker, Maven, npm, PyPI, Cargo, NuGet, and more)
 type: application
-version: 0.3.12
-appVersion: "0.9.2"
+version: 0.3.13
+appVersion: "0.9.3"
 annotations:
   artifacthub.io/category: integration-delivery
 home: https://github.com/getnora-io/nora

--- a/charts/nora/templates/configmap.yaml
+++ b/charts/nora/templates/configmap.yaml
@@ -17,6 +17,8 @@ data:
     public_url = {{ printf "%s://%s" $scheme $host | quote }}
     {{- else if and .Values.httpRoute.enabled .Values.httpRoute.hostnames }}
     public_url = {{ printf "https://%s" (index .Values.httpRoute.hostnames 0) | quote }}
+    {{- else }}
+    public_url = {{ printf "http://localhost:%d" (int .Values.config.server.port) | quote }}
     {{- end }}
 
     {{- if .Values.config.registries }}

--- a/charts/nora/templates/configmap.yaml
+++ b/charts/nora/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
     {{- else if and .Values.httpRoute.enabled .Values.httpRoute.hostnames }}
     public_url = {{ printf "https://%s" (index .Values.httpRoute.hostnames 0) | quote }}
     {{- else }}
-    public_url = {{ printf "http://localhost:%d" (int .Values.config.server.port) | quote }}
+    {{- fail "config.server.public_url is required when ingress and httpRoute are both disabled. Set config.server.public_url in your values (e.g. https://registry.example.com)." }}
     {{- end }}
 
     {{- if .Values.config.registries }}


### PR DESCRIPTION
## Summary

- appVersion: 0.8.4 → 0.9.3
- Chart version: 0.3.7 → 0.3.8
- Add `public_url` localhost fallback in configmap template

Since NORA v0.9.3, `public_url` is required when `host=0.0.0.0`. The template already derives it from ingress/httpRoute, but had no fallback for bare ClusterIP deployments. Now defaults to `http://localhost:<port>`.

## Reference

- NORA release: https://github.com/getnora-io/nora/releases/tag/v0.9.3